### PR TITLE
build(deps): ⬆️ bump zed_extension_api from 0.6.0 to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ee021e3a4c69d6ae90137fcf7537d1a8a5032dc9bf180c8fa6dd1a2f7c56d7"
+checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.6.0"
+zed_extension_api = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
## 🎯 What

Updates the Zed extension API from **0.6.0 → 0.7.0** and rebuilds against current `main` (which now includes the sha2 0.11 forward-fix).

## 🔧 Changes
- `Cargo.toml`: `zed_extension_api = "0.7.0"`
- `Cargo.lock`: regenerated (adds transitive `wit-bindgen-rt v0.41.0`)
- **No source changes** — the extension compiles cleanly to `wasm32-wasip1` on 0.7.0, matching the API surface already used by `zed-phpcs-lsp`.

## ✅ Verified locally
- Extension: `cargo fmt --check`, `cargo clippy --target wasm32-wasip1 -D warnings`, `cargo check --target wasm32-wasip1` — all pass
- LSP server crate: unaffected by this bump, green

## 📝 Context
This is the manual, reviewed follow-up to Dependabot PR #5 (closed). Done as a PR per request so the major-version bump gets a real rebuild + review rather than auto-merging.

Refs mike-bronner/zed-laravel#36