### PR TITLE
ci: 🐛 Pin release checkouts to bump commit and fix dispatch version input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
         new_version: ${{ steps.extract_version.outputs.version }}
+        new_commit_sha: ${{ steps.commit_changes.outputs.new_commit_sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -34,8 +35,9 @@ jobs:
       - name: Extract version from release tag
         id: extract_version
         run: |
+          # Release event provides tag_name; workflow_dispatch provides inputs.tag
           # Remove 'v' prefix if present (e.g., v1.2.3 -> 1.2.3)
-          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${{ github.event.release.tag_name || github.event.inputs.tag }}"
           VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Extracted version: ${VERSION}"
@@ -168,7 +170,12 @@ jobs:
             binary_name: phpmd-lsp-server-windows-arm64.exe
 
     steps:
+      # Pin to the version-bump commit: update-version force-moves the release
+      # tag, and a bare checkout of the moved tag fails actions/checkout's
+      # expected-commit validation.
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.update-version.outputs.new_commit_sha }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -235,9 +242,13 @@ jobs:
   download-phars:
     name: Download and Package PHAR Files
     runs-on: ubuntu-latest
+    needs: update-version
 
     steps:
+      # Pin to the version-bump commit — same race as build-lsp-server.
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.update-version.outputs.new_commit_sha }}
 
       - name: Download PHPMD
         run: |


### PR DESCRIPTION
## Summary

Release `0.1.3` ([run 27307704651](https://github.com/mike-bronner/zed-phpmd-lsp/actions/runs/27307704651)) failed because the `update-version` job force-moves the release tag onto its version-bump commit, after which the downstream build jobs' bare `actions/checkout` refused the moved tag ("does not point to the expected commit").

## Changes

- Expose the already-computed `new_commit_sha` as a job output of `update-version`
- Pin `build-lsp-server` and `download-phars` checkouts to that SHA — bypasses the moved-tag validation and guarantees binaries build from the bumped source
- `download-phars` now `needs: update-version` (it was only winning the race by scheduling luck)
- `extract_version` falls back to `github.event.inputs.tag` on `workflow_dispatch` — previously it read the empty `release.tag_name` and would have sed'd `version = ""` into all three TOML files

## Test plan

- `actionlint` findings identical to main (six pre-existing, info-level / old toolchain action — none introduced)
- YAML parses
- `cargo check` passes on main at the bump commit, so re-creating release 0.1.3 after merge should go green