### PR TITLE
Parse-failure log dumps full PHPMD output to stderr without truncation

### DIFF
--- a/lsp-server/src/main.rs
+++ b/lsp-server/src/main.rs
@@ -749,7 +749,7 @@ impl PhpmdLanguageServer {
             Ok(result) => result,
             Err(e) => {
                 eprintln!("❌ PHPMD LSP: Failed to parse JSON output: {}", e);
-                eprintln!("Raw output: {}", json_output);
+                eprintln!("Raw output: {}", truncate_for_log(json_output, 500));
                 return Ok(vec![]);
             }
         };


### PR DESCRIPTION
## Summary
Implements #39 — a follow-up from Holmes's review of #36 (PR #37).

The `Err` arm of the JSON parse in `parse_phpmd_output` dumped the full `json_output` to stderr with no length cap (`lsp-server/src/main.rs:752`). A large or malformed PHPMD response could flood the LSP server's stderr, which some editor integrations capture, display, or persist. This was the one logging-truncation site left on the unbounded path after PR #37 bounded the others.

## Changes
- `lsp-server/src/main.rs` — route the parse-failure `Raw output:` dump through the existing `truncate_for_log` helper with a 500-char cap, matching the bounded debug site at `:620`. One-line wiring change; parse behaviour and return value untouched.

## Acceptance Criteria
- [x] The `Raw output:` log in the JSON parse-failure branch (`Err(e)` arm of `serde_json::from_str`) wraps `json_output` with `truncate_for_log(json_output, 500)`, matching the 500-char cap used at the line-620 debug site.
- [x] No other unbounded `eprintln!` / `eprint!` calls that emit `json_output` (or any other full PHPMD stdout capture) remain in `main.rs` (line 620 was already bounded; 752 was the last).
- [x] JSON parsing behaviour and return value are unchanged — only the error-path log line is modified.
- [x] `cargo test` passes, including the existing `truncate_for_log_*` suite in `mod tests`.

## Test Plan
- [x] `cargo test --all-features` — all 10 tests pass, including the four `truncate_for_log_*` tests that guard the truncation invariant (the AC's named regression coverage).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.

**On test coverage:** this wires an already-fully-tested helper into one `eprintln!` call site. The sibling truncation sites from #37 (`:620`, `:1139`) carry no call-site-specific tests — the repo's convention is to test `truncate_for_log` directly, and that suite already covers the invariant. No new test was added so as not to impose a stderr-capture convention mid-stream.

Fixes #39